### PR TITLE
Revert "OHT-34 testing env"

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+CKAN_SQLALCHEMY_URL = postgresql://ckan:12345678@192.168.49.2/ckan_test
+CKAN_DATASTORE_WRITE_URL = postgresql://ckan:12345678@192.168.49.2/datastore_test
+CKAN_DATASTORE_READ_URL = postgresql://ckan:12345678@192.168.49.2/datastore_test
+CKAN_SOLR_URL = http://192.168.49.2:8983/solr/ckan
+CKAN_REDIS_URL = redis://192.168.49.2:6379/1
+CKAN_STORAGE_PATH = ./build/ckan_storage

--- a/test_env.sh
+++ b/test_env.sh
@@ -1,6 +1,0 @@
-export CKAN_SQLALCHEMY_URL=postgresql://ckan:12345678@192.168.49.2/ckan_test
-export CKAN_DATASTORE_WRITE_URL=postgresql://ckan:12345678@192.168.49.2/datastore_test
-export CKAN_DATASTORE_READ_URL=postgresql://ckan:12345678@192.168.49.2/datastore_test
-export CKAN_SOLR_URL=http://192.168.49.2:8983/solr/ckan
-export CKAN_REDIS_URL=redis://192.168.49.2:6379/1
-export CKAN_STORAGE_PATH=./build/ckan_storage


### PR DESCRIPTION
Reverts fjelltopp/one_health_tool#6

We have merged https://github.com/fjelltopp/fjelltopp-infrastructure/pull/114 meaning this change is no longer required. 