### PR TITLE
OHT-44 ignore prod and dev demo data configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 .pdbhistory
 .cache/
 build/
+util/demo_data_loader/prod_config.json
+util/demo_data_loader/dev_config.json


### PR DESCRIPTION
I have created config files to push demo data to the cloud.  I would like to store them with the existing config file for local environment, and I would also like them to be ignored by git.